### PR TITLE
[FIX] Missing openssl dependency.

### DIFF
--- a/mutt-patched.rb
+++ b/mutt-patched.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class MuttPatched < Formula
   homepage 'http://www.mutt.org/'
-  url 'ftp://ftp.mutt.org/mutt/devel/mutt-1.5.23.tar.gz'
-  mirror 'https://bitbucket.org/mutt/mutt/downloads/mutt-1.5.23.tar.gz'
-  sha1 '8ac821d8b1e25504a31bf5fda9c08d93a4acc862'
+  url 'ftp://ftp.mutt.org/pub/mutt/mutt-1.5.24.tar.gz'
+  mirror 'https://bitbucket.org/mutt/mutt/downloads/mutt-1.5.24.tar.gz'
+  sha1 '38a2da5eb01ff83a90a2caee28fa2e95dbfe6898'
 
   head do
     url 'http://dev.mutt.org/hg/mutt#default', :using => :hg
@@ -44,6 +44,7 @@ class MuttPatched < Formula
   option "with-date-conditional-patch", "Apply conditional date patch"
 
   depends_on 'tokyo-cabinet'
+  depends_on 'openssl'
   depends_on 's-lang' => :optional
 
   def patches


### PR DESCRIPTION
Update Mutt to 1.5.24 and fix openssl dependency.